### PR TITLE
Home deletion

### DIFF
--- a/packages/express_backend/models/Home-Services.test.ts
+++ b/packages/express_backend/models/Home-Services.test.ts
@@ -8,6 +8,7 @@ import {
 	getHomeByCode,
 	getHomesByUserAndRelation,
 	getHomesByUser,
+	getHomeByName,
 } from "./Home-Services";
 
 import { Home } from "./Home";

--- a/packages/express_backend/models/Home-Services.test.ts
+++ b/packages/express_backend/models/Home-Services.test.ts
@@ -81,6 +81,13 @@ test("Fetching (getting) a home", async () => {
 	expect(fetched._id.toString()).toBe(h._id.toString());
 });
 
+test("Fetching (getting) a home by name", async () => {
+	const fetched = await getHomeByName(h.homeName);
+	if (!fetched) return;
+	expect(fetched).toBeDefined();
+	expect(fetched._id.toString()).toBe(h._id.toString());
+});
+
 test("Fetching (getting) a home by Code", async () => {
 	homeCode = h.homeCode;
 	const home = await getHomeByCode(homeCode);

--- a/packages/express_backend/models/Home-Services.ts
+++ b/packages/express_backend/models/Home-Services.ts
@@ -14,6 +14,10 @@ export function getHomeByCode(homeCode: string) {
 	return Home.findOne({ homeCode: homeCode });
 }
 
+export function getHomeByName(homeName: string) {
+	return Home.findOne({ homeName: homeName });
+}
+
 export function getHomesByUser(userId: mongoose.Types.ObjectId) {
 	return Home.find({ userIds: { $elemMatch: { userId: userId } } });
 }

--- a/packages/express_backend/routes/relation-routes.ts
+++ b/packages/express_backend/routes/relation-routes.ts
@@ -70,7 +70,7 @@ relationRouter.patch(
 	async (req: Request, res: Response) => {
 		try {
 			console.log("Deleting relation!");
-			const relationship = req.body.relationship;
+
 			const h = await getHomeByName(req.params.homeName);
 
 			if (!h) {

--- a/packages/express_backend/routes/relation-routes.ts
+++ b/packages/express_backend/routes/relation-routes.ts
@@ -1,20 +1,17 @@
 import express from "express";
 import type { Request, Response } from "express";
-import { getHomeByCode, getHomesByUser } from "../models/Home-Services.ts";
+import {
+	getHomeByCode,
+	getHomesByUser,
+	getHomeByName,
+	updateHome,
+} from "../models/Home-Services.ts";
 import {
 	getUserByUsername,
 	getUsersByHomeAndRelation,
+	updateUserById,
 } from "../models/User-Services.ts";
 import mongoose from "mongoose";
-
-interface UserRelation {
-	userId: mongoose.Schema.Types.ObjectId;
-	relationship: string;
-}
-interface HomeRelation {
-	userId: mongoose.Schema.Types.ObjectId;
-	relationship: string;
-}
 
 export const relationRouter = express.Router();
 
@@ -36,6 +33,7 @@ relationRouter.post(
 			if (!u) {
 				return res.status(404).json({ error: "User not found" });
 			}
+
 			h.userIds.push({ userId: u._id, relationship: relationship });
 			await h.save();
 			u.homeIds.push({ homeId: h._id, relationship: relationship });
@@ -65,3 +63,39 @@ relationRouter.get("/relate/:username", async (req: Request, res: Response) => {
 		res.status(500).json({ error: "Failed to fetch homes from user" });
 	}
 });
+
+//deletes a relation between user and home, used when a user leaves a home
+relationRouter.patch(
+	"/relate/:username/:homeName",
+	async (req: Request, res: Response) => {
+		try {
+			console.log("Deleting relation!");
+			const relationship = req.body.relationship;
+			const h = await getHomeByName(req.params.homeName);
+
+			if (!h) {
+				return res.status(404).json({ error: "Home not found" });
+			}
+
+			const u = await getUserByUsername(req.params.username);
+
+			if (!u) {
+				return res.status(404).json({ error: "User not found" });
+			}
+			const removeOneUser = h.userIds.filter((userIds) => {
+				return userIds.userId !== u._id;
+			});
+			const removeOneHome = u.homeIds.filter((homeIds) => {
+				return homeIds.homeId !== h._id;
+			});
+
+			await updateHome(h._id, { userIds: removeOneUser });
+			await updateUserById(u._id, { homeIds: removeOneHome });
+
+			res.status(200).json(h);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: "Failed to create relationship" });
+		}
+	}
+);

--- a/packages/express_backend/routes/relation-routes.ts
+++ b/packages/express_backend/routes/relation-routes.ts
@@ -82,20 +82,36 @@ relationRouter.patch(
 			if (!u) {
 				return res.status(404).json({ error: "User not found" });
 			}
-			const removeOneUser = h.userIds.filter((userIds) => {
-				return userIds.userId !== u._id;
-			});
-			const removeOneHome = u.homeIds.filter((homeIds) => {
-				return homeIds.homeId !== h._id;
-			});
+			const removeOneUser = h.userIds.filter(
+				(user) => !user.userId.equals(u._id)
+			);
+			const removeOneHome = u.homeIds.filter(
+				(home) => !home.homeId.equals(h._id)
+			);
 
-			await updateHome(h._id, { userIds: removeOneUser });
-			await updateUserById(u._id, { homeIds: removeOneHome });
+			const updatedHome = await updateHome(h._id, {
+				userIds: removeOneUser,
+			});
+			if (!updatedHome) {
+				return res
+					.status(404)
+					.json({ error: "Home not found for update" });
+			}
+			await h.save();
+			const updatedUser = await updateUserById(u._id, {
+				homeIds: removeOneHome,
+			});
+			if (!updatedUser) {
+				return res
+					.status(404)
+					.json({ error: "User not found for update" });
+			}
+			await u.save();
 
 			res.status(200).json(h);
 		} catch (err) {
 			console.error(err);
-			res.status(500).json({ error: "Failed to create relationship" });
+			res.status(500).json({ error: "Failed to remove relationship" });
 		}
 	}
 );

--- a/packages/react-frontend/src/components/addHomeOverlay.tsx
+++ b/packages/react-frontend/src/components/addHomeOverlay.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { useState } from "react";
-//import mongoose from "mongoose";
 
 /*component is to add a new home based off a given code*/
 

--- a/packages/react-frontend/src/components/list.tsx
+++ b/packages/react-frontend/src/components/list.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
 	faCalendar,
@@ -7,6 +7,7 @@ import {
 	faFileContract,
 	faAngleRight,
 	faPeopleRoof,
+	faTrashCan,
 } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 
@@ -20,7 +21,7 @@ interface ListProps {
 	item: string;
 	items: string[];
 	handleAddClick: () => void;
-	handleRemoveClick: () => void;
+	handleRemoveClick: (item: string) => void;
 }
 
 export default function List({
@@ -29,6 +30,7 @@ export default function List({
 	handleAddClick,
 	handleRemoveClick,
 }: ListProps) {
+	const [remove, setRemove] = useState(false);
 	return (
 		<div className="flex flex-col gap-2 panel animate-floatUp">
 			<h1 className="header-secondary">Current {item}</h1>
@@ -38,9 +40,9 @@ export default function List({
 						className="list-item font-bold animate-floatUp"
 						key={index}
 					>
-						<span className="flex flex-row  ">
+						<span className="flex flex-row ">
 							{listItem}
-							{item == "Home Spaces" && (
+							{item == "Home Spaces" && remove == false && (
 								<div className="relative ml-auto gap-4 self-end-safe ">
 									<Link to="/roommmates">
 										{" "}
@@ -92,11 +94,22 @@ export default function List({
 									</Link>
 								</div>
 							)}
+							{item == "Home Spaces" && remove == true && (
+								<div className="relative ml-auto self-end-safe">
+									<FontAwesomeIcon
+										className="iconWrapper"
+										icon={faTrashCan}
+										onClick={() => {
+											handleRemoveClick(listItem);
+										}}
+									/>
+								</div>
+							)}
 						</span>
 					</li>
 				))}
 			</ul>
-			{item == "Home Spaces" && (
+			{item == "Home Spaces" && remove == false && (
 				<div className="flex flex-row flex-center self-center gap-4">
 					<button
 						onClick={handleAddClick}
@@ -105,11 +118,18 @@ export default function List({
 						+
 					</button>
 					<button
-						onClick={handleRemoveClick}
+						onClick={() => {
+							setRemove(true);
+						}}
 						className="button self-center"
 					>
 						-
 					</button>
+				</div>
+			)}
+			{item == "Home Spaces" && remove == true && (
+				<div className="button self-center">
+					<button onClick={() => setRemove(false)}> Cancel </button>
 				</div>
 			)}
 		</div>

--- a/packages/react-frontend/src/components/list.tsx
+++ b/packages/react-frontend/src/components/list.tsx
@@ -35,6 +35,11 @@ export default function List({
 		<div className="flex flex-col gap-2 panel animate-floatUp">
 			<h1 className="header-secondary">Current {item}</h1>
 			<ul>
+				{items.length == 0 && (
+					<li className="list-item font-bold animate-floatUp">
+						No {item}
+					</li>
+				)}
 				{items.map((listItem, index) => (
 					<li
 						className="list-item font-bold animate-floatUp"

--- a/packages/react-frontend/src/components/removeHomeOverlay.tsx
+++ b/packages/react-frontend/src/components/removeHomeOverlay.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { useState } from "react";
+
+/*component is to add a new home based off a given code*/
+
+type RemoveHomeProps = {
+	onRemove: any;
+	homeRemove: string | undefined;
+	onCancel: (data: boolean) => void;
+	username: string | undefined;
+};
+
+export default function RemoveHomeOverlay({
+	onRemove,
+	onCancel,
+	homeRemove,
+	username,
+}: RemoveHomeProps) {
+	async function removeHome() {
+		if (!username || !homeRemove) return;
+		console.log("connecting home to user!");
+
+		const promise = await fetch(
+			`http://localhost:8000/relate/${username}/${homeRemove}`,
+			{
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		return promise;
+	}
+	async function handleRemoveHome() {
+		removeHome()
+			.then((res) => (res?.ok ? res.json() : undefined))
+			.then((json) => {
+				onRemove(json);
+			})
+			.catch((error) => console.error("Error removing home:", error));
+	}
+
+	return (
+		<div className="flex flex-col gap-2 animate-floatUp">
+			<h1 className="header-secondary self-center">
+				Are you sure you want to remove {homeRemove}?
+			</h1>
+			<div className="flex flex-row gap-4 self-center">
+				<button
+					className="button self-center"
+					onClick={() => onCancel(false)}
+				>
+					Cancel
+				</button>
+				<button
+					className="button self-center"
+					onClick={handleRemoveHome}
+				>
+					Remove
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/react-frontend/src/homelist.tsx
+++ b/packages/react-frontend/src/homelist.tsx
@@ -45,7 +45,7 @@ export default function HomeList() {
 	async function fetchHomes() {
 		if (!username) return;
 
-		const res = fetch(`http://localhost:8000/relate/${username}`)
+		fetch(`http://localhost:8000/relate/${username}`)
 			.then((res) => {
 				if (!res.ok) throw new Error("Homes not found");
 				return res.json();
@@ -112,22 +112,12 @@ export default function HomeList() {
 					/>
 				)}
 			</Overlay>
-			{homeNames.length > 0 && (
-				<List
-					item="Home Spaces"
-					items={homeNames}
-					handleAddClick={handleAddClick}
-					handleRemoveClick={handleRemoveClick}
-				/>
-			)}
-			{homeNames.length == 0 && (
-				<List
-					item="Home Spaces"
-					items={["No Homes: Add below"]}
-					handleAddClick={handleAddClick}
-					handleRemoveClick={() => {}}
-				/>
-			)}
+			<List
+				item="Home Spaces"
+				items={homeNames}
+				handleAddClick={handleAddClick}
+				handleRemoveClick={handleRemoveClick}
+			/>
 		</div>
 	);
 }

--- a/packages/react-frontend/src/homelist.tsx
+++ b/packages/react-frontend/src/homelist.tsx
@@ -54,13 +54,6 @@ export default function HomeList() {
 			<h1 className="header">Home Spaces</h1>
 			<div className="iconWrapper">
 				<Link to={`/settings/${username}`}>
-					{/* <img
-						src="/assets/settings.png"
-						alt="Settings Icon"
-						width={60}
-						height={60}
-						className="w-20 h-20"
-					/> */}
 					<FontAwesomeIcon
 						icon={faUserGear}
 						className="w-20 h-20 absolute top-15 right-15 text-7xl"

--- a/packages/react-frontend/src/homelist.tsx
+++ b/packages/react-frontend/src/homelist.tsx
@@ -7,18 +7,17 @@ import AddHomeOverlay from "./components/addHomeOverlay";
 import CreateHomeOverlay from "./components/createHomeOverlay";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUserGear } from "@fortawesome/free-solid-svg-icons";
+import RemoveHomeOverlay from "./components/removeHomeOverlay";
 
 export default function HomeList() {
 	const [homes, setHomes] = useState<any[]>([]);
 	const { username } = useParams();
 	const [overlayOpen, setOverlayOpen] = useState(false);
 	const [addState, setAddState] = useState("Base");
+	const [homeDelete, setHomeDelete] = useState();
 	const handleAddClick = () => {
 		console.log("Add!" + overlayOpen);
 		setOverlayOpen(true);
-	};
-	const handleRemoveClick = () => {
-		console.log("Remove!");
 	};
 	const handleClose = () => {
 		console.log("Closed!");
@@ -30,6 +29,19 @@ export default function HomeList() {
 		setHomes((prev) => [...prev, data]);
 		handleClose();
 	}
+
+	async function handleRemove(data: any) {
+		setHomes(homes.filter((h) => h._id !== data._id));
+		handleClose();
+	}
+
+	async function handleRemoveClick(data: any) {
+		console.log("Remove " + data);
+		setHomeDelete(data);
+		setAddState("Remove");
+		setOverlayOpen(true);
+	}
+
 	async function fetchHomes() {
 		if (!username) return;
 
@@ -86,6 +98,19 @@ export default function HomeList() {
 						}}
 					/>
 				)}
+				{addState == "Remove" && (
+					<RemoveHomeOverlay
+						username={username}
+						homeRemove={homeDelete}
+						onRemove={(data: any) => {
+							handleRemove(data);
+						}}
+						onCancel={() => {
+							setOverlayOpen(false);
+							setAddState("Base");
+						}}
+					/>
+				)}
 			</Overlay>
 			{homeNames.length > 0 && (
 				<List
@@ -100,7 +125,7 @@ export default function HomeList() {
 					item="Home Spaces"
 					items={["No Homes: Add below"]}
 					handleAddClick={handleAddClick}
-					handleRemoveClick={handleRemoveClick}
+					handleRemoveClick={() => {}}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
# Summary of implementation



# Problem and Solution

Before, users can add to homes but couldn't remove themselves from a home. Now implemented a feature for users to be removed. This is done by clicking the list's remove button, a trash can icon, and then hitting remove when prompted if they want to remove a home. I believe this three step process makes it so a user cannot accidentally remove a home, and cannot accidentally remove a different home than they intended.  
Consequently, implemented icons and the ability for the list component prompt removal of items from it's list (the actual routing for removal will be done outside of the list component). 
Furthermore, slightly altered how the list handles an empty list, before it didn't and would display nothing (needing something to be passed in to display anything), now when an empty list is passed in, properly displays the list is empty of items.  

# File Changes

homelist.tsx, removeHomeOverlay.tsx, relation-route.ts, home-services.ts (added in ability to find home by homeName)

# Breaking Changes

Alters how the list component works slightly (now has trashcan icon and handles the remove button being clicked and handles empty list), double check every page with this list component implemented hasn't broken.


# How was this tested?


-  ran npm run test and all pass
- Can remove a home, can cancel removing a home, can still add a home, no icons when list empty, a home stays deleted upon refresh
- Tried to remove two at once (by trying to click multiple trash icons), unsure what other edge cases could be done

# Setup and Checklist for reviewers

- [x] npm run test and all pass
- [x] Can remove a home, can cancel removing a home, can still add a home, no icons when list empty, a home stays deleted upon refresh
- [x] Try to remove two at once and cannot delete more than one home at a time

# Issues linked

closes #125 
