### PR TITLE
Rules page

### DIFF
--- a/packages/express_backend/models/Home-Services.ts
+++ b/packages/express_backend/models/Home-Services.ts
@@ -41,7 +41,6 @@ export function deleteHome(homeId: mongoose.Types.ObjectId) {
 	return Home.findByIdAndDelete({ _id: homeId });
 }
 
-//added
 export function addResidentToHome(
 	homeId: mongoose.Types.ObjectId,
 	userId: mongoose.Types.ObjectId

--- a/packages/express_backend/models/Home-Services.ts
+++ b/packages/express_backend/models/Home-Services.ts
@@ -41,6 +41,28 @@ export function deleteHome(homeId: mongoose.Types.ObjectId) {
 	return Home.findByIdAndDelete({ _id: homeId });
 }
 
+//added
+export function addResidentToHome(
+	homeId: mongoose.Types.ObjectId,
+	userId: mongoose.Types.ObjectId
+) {
+	return Home.findByIdAndUpdate(
+		homeId,
+		{
+			$addToSet: {
+				userIds: {
+					userId,
+					relationship: "RESIDENT",
+				},
+			},
+		},
+		{
+			returnDocument: "after",
+			runValidators: true,
+		}
+	);
+}
+
 // commenting for coverage
 // export function addMember(user: string) {
 // 	//FIXME this will be changed to user Schema, users should store Home id's

--- a/packages/express_backend/models/User.ts
+++ b/packages/express_backend/models/User.ts
@@ -121,7 +121,7 @@ export const UserSchema = new mongoose.Schema(
 					type: mongoose.Schema.Types.ObjectId,
 					ref: "Home",
 					required: true,
-					unique: true,
+					//unique: true,
 				},
 				relationship: {
 					type: String,

--- a/packages/express_backend/routes/home-routes.ts
+++ b/packages/express_backend/routes/home-routes.ts
@@ -6,7 +6,6 @@ import {
 	updateHome,
 	deleteHome,
 	getHomeByCode,
-	addResidentToHome,
 	// addMember,
 	// removeMember,
 } from "../models/Home-Services";
@@ -85,12 +84,12 @@ homeRouter.post(
 	"/homes/id/:id/members",
 	async (req: Request, res: Response) => {
 		try {
-			const updatedHome = await addResidentToHome(
-				req.params.id as any,
-				req.body.userId as any
-			);
-
-			res.status(201).json(updatedHome);
+			const relationship = await createRelationship({
+				home: req.params.id,
+				user: req.body.userId,
+				type: "resident",
+			});
+			res.status(201).json(relationship);
 		} catch (error) {
 			console.error(error);
 			res.status(400).json({ error: "Failed to add resident" });

--- a/packages/express_backend/routes/home-routes.ts
+++ b/packages/express_backend/routes/home-routes.ts
@@ -6,6 +6,7 @@ import {
 	updateHome,
 	deleteHome,
 	getHomeByCode,
+	addResidentToHome,
 	// addMember,
 	// removeMember,
 } from "../models/Home-Services";
@@ -84,12 +85,12 @@ homeRouter.post(
 	"/homes/id/:id/members",
 	async (req: Request, res: Response) => {
 		try {
-			const relationship = await createRelationship({
-				home: req.params.id,
-				user: req.body.userId,
-				type: "resident",
-			});
-			res.status(201).json(relationship);
+			const updatedHome = await addResidentToHome(
+				req.params.id as any,
+				req.body.userId as any
+			);
+
+			res.status(201).json(updatedHome);
 		} catch (error) {
 			console.error(error);
 			res.status(400).json({ error: "Failed to add resident" });

--- a/packages/express_backend/routes/relation-routes.ts
+++ b/packages/express_backend/routes/relation-routes.ts
@@ -21,7 +21,7 @@ relationRouter.post(
 	"/relate/:username/:homeCode",
 	async (req: Request, res: Response) => {
 		try {
-			const relationship = req.body.relationship;
+			const relationship = req.body.relationship.toUpperCase();
 
 			const h = await getHomeByCode(req.params.homeCode);
 
@@ -123,6 +123,27 @@ relationRouter.patch(
 		} catch (err) {
 			console.error(err);
 			res.status(500).json({ error: "Failed to remove relationship" });
+		}
+	}
+);
+
+relationRouter.get(
+	"/relate/home/:homeId/residents",
+	async (req: Request, res: Response) => {
+		try {
+			const residents = await getUsersByHomeAndRelation(
+				new mongoose.Types.ObjectId(req.params.homeId),
+				"RESIDENT"
+			);
+
+			res.status(200).json({
+				count: residents.length,
+			});
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({
+				error: "Failed to fetch residents",
+			});
 		}
 	}
 );

--- a/packages/express_backend/routes/rule-routes.ts
+++ b/packages/express_backend/routes/rule-routes.ts
@@ -1,6 +1,8 @@
 import express from "express";
 import mongoose from "mongoose";
 import type { Request, Response } from "express";
+import { Home } from "../models/Home";
+
 
 import { getHomeByCode } from "../models/Home-Services";
 import {
@@ -90,6 +92,20 @@ ruleRouter.post("/homes/rules", async (req: Request, res: Response) => {
 	}
 });
 
+
+//get number of residents
+async function getResidentCount(homeId: mongoose.Types.ObjectId) {
+	const home = await Home.findById(homeId);
+
+	if (!home) {
+		throw new Error("Home not found");
+	}
+	return home.userIds.filter(
+		(user) => user.relationship === "RESIDENT"
+	).length;
+}
+
+
 // Update rule
 ruleRouter.put("/rules/:ruleId", async (req: Request, res: Response) => {
 	try {
@@ -143,7 +159,14 @@ ruleRouter.post("/rules/:ruleId/vote", async (req: Request, res: Response) => {
 		const yes = rule.votes.filter((v) => v.vote === "YES").length;
 		const no = rule.votes.filter((v) => v.vote === "NO").length;
 
-		const TOTAL_RESIDENTS = 4;
+		const TOTAL_RESIDENTS = await getResidentCount(rule.homeId);
+
+		//safety check if no residents
+		if (TOTAL_RESIDENTS === 0) {
+			return res.status(400).json({
+				error: "No residents found for home",
+			});
+		}
 
 		if (no > 0) {
 			rule.status = "REJECTED";
@@ -187,7 +210,14 @@ ruleRouter.post(
 			const yes = rule.deleteVotes.filter((v) => v.vote === "YES").length;
 			const no = rule.deleteVotes.filter((v) => v.vote === "NO").length;
 
-			const TOTAL_RESIDENTS = 4;
+			const TOTAL_RESIDENTS = await getResidentCount(rule.homeId);
+
+			//safety check if no residents
+			if (TOTAL_RESIDENTS === 0) {
+				return res.status(400).json({
+					error: "No residents found for home",
+				});
+			}
 
 			if (no > 0) {
 				rule.deleteStatus = "REJECTED";

--- a/packages/express_backend/routes/rule-routes.ts
+++ b/packages/express_backend/routes/rule-routes.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import mongoose from "mongoose";
 import type { Request, Response } from "express";
-import { Home } from "../models/Home";
+import { getUsersByHomeAndRelation } from "../models/User-Services";
 
 
 import { getHomeByCode } from "../models/Home-Services";
@@ -95,14 +95,12 @@ ruleRouter.post("/homes/rules", async (req: Request, res: Response) => {
 
 //get number of residents
 async function getResidentCount(homeId: mongoose.Types.ObjectId) {
-	const home = await Home.findById(homeId);
+	const residents = await getUsersByHomeAndRelation(
+		homeId,
+		"RESIDENT"
+	);
 
-	if (!home) {
-		throw new Error("Home not found");
-	}
-	return home.userIds.filter(
-		(user) => user.relationship === "RESIDENT"
-	).length;
+	return residents.length;
 }
 
 

--- a/packages/react-frontend/src/components/RuleCard.tsx
+++ b/packages/react-frontend/src/components/RuleCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import VotePanel from "./VotePanel";
 
-const TOTAL_RESIDENTS = 4;
 
 interface Vote {
 	voteId: string;
@@ -18,10 +17,11 @@ interface Rule {
 interface RuleCardProps {
 	rule: Rule;
 	voteId: string;
+	totalResidents: number;
 	onVote: (ruleId: string, vote: "YES" | "NO") => void;
 }
 
-export default function RuleCard({ rule, voteId, onVote }: RuleCardProps) {
+export default function RuleCard({ rule, voteId, totalResidents, onVote }: RuleCardProps) {
 	const yes = rule.votes?.filter((v) => v.vote === "YES").length || 0;
 	const no = rule.votes?.filter((v) => v.vote === "NO").length || 0;
 
@@ -40,7 +40,7 @@ export default function RuleCard({ rule, voteId, onVote }: RuleCardProps) {
 				<p className="text-lg">{rule.description}</p>
 				<p className="text-sm mt-2">{statusText}</p>
 				<p className="text-xs text-text/70 mt-1">
-					YES {yes} | NO {no} | Total Roommates {TOTAL_RESIDENTS}
+					YES {yes} | NO {no} | Total Roommates {totalResidents}
 				</p>
 			</div>
 

--- a/packages/react-frontend/src/pages/rulesPage.tsx
+++ b/packages/react-frontend/src/pages/rulesPage.tsx
@@ -24,6 +24,7 @@ export default function RulesPage() {
 	const [homeName, setHomeName] = useState("");
 	const [overlayOpen, setOverlayOpen] = useState(false);
 	const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+	const [totalResidents, setTotalResidents] = useState(0);
 
 	const { homeCode = "" } = useParams();
 	const navigate = useNavigate();
@@ -52,6 +53,12 @@ export default function RulesPage() {
 		const homeData = await homeRes.json();
 
 		setHomeName(homeData.homeName);
+
+		const residentCount = homeData.userIds.filter(
+			(user: any) => user.relationship === "RESIDENT"
+		).length || 0;
+
+		setTotalResidents(residentCount);
 
 		const rulesRes = await fetch(
 			`http://localhost:8000/homes/rules/${homeCode}`
@@ -117,7 +124,12 @@ export default function RulesPage() {
 	}
 
 	const renderRule = (rule: Rule) => (
-		<RuleCard rule={rule} voteId={voteId} onVote={handleVote} />
+		<RuleCard
+			rule={rule}
+			voteId={voteId}
+			totalResidents={totalResidents}
+			onVote={handleVote}
+		/>
 	);
 
 	return (
@@ -175,7 +187,7 @@ export default function RulesPage() {
 					voteId={voteId}
 					deleteVotes={selectedRule.deleteVotes || []}
 					deleteStatus={selectedRule.deleteStatus || "NONE"}
-					totalResidents={4}
+					totalResidents={totalResidents}
 					onVote={handleDeleteVote}
 					onCancel={() => setDeleteTarget(null)}
 				/>

--- a/packages/react-frontend/src/pages/rulesPage.tsx
+++ b/packages/react-frontend/src/pages/rulesPage.tsx
@@ -54,11 +54,17 @@ export default function RulesPage() {
 
 		setHomeName(homeData.homeName);
 
-		const residentCount = homeData.userIds.filter(
-			(user: any) => user.relationship === "RESIDENT"
-		).length || 0;
+		const residentRes = await fetch(
+			`http://localhost:8000/relate/home/${homeData._id}/residents`
+		);
 
-		setTotalResidents(residentCount);
+		if (!residentRes.ok) {
+			throw new Error("Failed to fetch residents");
+		}
+
+		const residentData = await residentRes.json();
+
+		setTotalResidents(residentData.count);
 
 		const rulesRes = await fetch(
 			`http://localhost:8000/homes/rules/${homeCode}`


### PR DESCRIPTION
# Summary of implementation

Fixed the hardcoded roommate count by switching the rules system to use dynamic resident counts based on home relationships. Added a new relation route to count residents in a home.

# Problem and Solution

The old roommate count logic was hardcoded and did not correctly match the number of roomates. This update adds a new function that counts residents through the relation system so roommate totals and voting now update correctly.

# File Changes
routes/relation-routes.ts:
- Added a new route to count residents in a home
- Added code that uses relation queries instead of hardcoded counts

routes/rule-routes.ts:
- Added a helper function to get the number of residents
- Updated voting logic to use dynamic resident counts

pages/RulesPage.tsx:
- Fetches roommate count from the new backend endpoint

components/RuleCard.tsx:
- Displays updated roommate totals next to vote counts

# Breaking Changes
None

# How was this tested?
- Tested locally with multiple users joining homes
- Verified roommate totals update correctly
- Verified voting updates correctly based on resident count
- Verified roommate totals change after adding additional users

# Setup and Checklist for reviewers

- [x] Run `npm run dev`
- [x] Navigate to the rules page and verify roommate totals display correctly
- [x] Create a new user and join a home
- [x] Verify roommate totals update after a user joins
- [x] Test voting with multiple users and confirm rule status updates correctly

# Issues linked

closes #159 
