### PR TITLE
feat: hash user passwords in backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 			],
 			"dependencies": {
 				"@maptiler/geocoding-control": "^3.0.0",
+				"bcrypt": "^6.0.0",
 				"connect-mongo": "^6.0.0",
 				"cors": "^2.8.6",
 				"dotenv": "^17.3.1",
@@ -34,6 +35,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
+				"@types/bcrypt": "^6.0.0",
 				"@types/cors": "^2.8.19",
 				"@types/express-session": "^1.19.0",
 				"@types/jest": "^30.0.0",
@@ -4867,6 +4869,16 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/bcrypt": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+			"integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.6",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -6471,6 +6483,20 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/bcrypt": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+			"integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^8.3.0",
+				"node-gyp-build": "^4.8.4"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/bidi-js": {
@@ -11862,6 +11888,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/node-addon-api": {
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+			"integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
 		"node_modules/node-exports-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -11879,6 +11914,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
+		"@types/bcrypt": "^6.0.0",
 		"@types/cors": "^2.8.19",
 		"@types/express-session": "^1.19.0",
 		"@types/jest": "^30.0.0",
@@ -68,6 +69,7 @@
 	},
 	"dependencies": {
 		"@maptiler/geocoding-control": "^3.0.0",
+		"bcrypt": "^6.0.0",
 		"connect-mongo": "^6.0.0",
 		"cors": "^2.8.6",
 		"dotenv": "^17.3.1",

--- a/packages/express_backend/models/User-Services-Mock.test.ts
+++ b/packages/express_backend/models/User-Services-Mock.test.ts
@@ -1,4 +1,5 @@
 import mockingoose from "mockingoose";
+import bcrypt from "bcrypt";
 import mongoose from "mongoose";
 import { expect, test, beforeEach } from "@jest/globals";
 import { User } from "./User";
@@ -42,7 +43,14 @@ test("Creating a user", async () => {
 
 	expect(created).toBeDefined();
 	expect(created.username).toBe(dummyUser.username);
-	expect(created.password).toBe(dummyUser.password);
+	expect(created.password).not.toBe(dummyUser.password);
+
+	const passwordMatches = await bcrypt.compare(
+		dummyUser.password,
+		created.password
+	);
+
+	expect(passwordMatches).toBe(true);
 	expect(created.fullName).toBe(dummyUser.fullName);
 	expect(created.phone).toBe(dummyUser.phone);
 	expect(created.pronouns).toBe(dummyUser.pronouns);
@@ -106,7 +114,7 @@ test("Getting users by home ID", async () => {
 	expect(fetched[0].username).toBe(user.username);
 });
 
-test("Updating a user by ID", async () => {
+test("Updating a user by ID without password does not hash password", async () => {
 	const user = new User(dummyUser);
 	const updatedDoc = new User({
 		...dummyUser,
@@ -116,12 +124,41 @@ test("Updating a user by ID", async () => {
 	mockingoose(User).toReturn(updatedDoc, "findOneAndUpdate");
 
 	const updated = await updateUserById(user._id, {
-		...dummyUser,
 		fullName: "Barry B. Benson Jr.",
 	});
 
 	expect(updated).toBeDefined();
 	expect(updated?.fullName).toBe("Barry B. Benson Jr.");
+});
+
+test("Updating a user by ID hashes password when password is updated", async () => {
+	const user = new User(dummyUser);
+	const updatedPassword = "newhoneypassword";
+	const hashUpdatedPassword = await bcrypt.hash(updatedPassword, 12);
+	const updatedDoc = new User({
+		...dummyUser,
+		password: hashUpdatedPassword,
+		fullName: "Barry B. Benson Jr.",
+	});
+	updatedDoc._id = user._id;
+	mockingoose(User).toReturn(updatedDoc, "findOneAndUpdate");
+
+	const updated = await updateUserById(user._id, {
+		...dummyUser,
+		password: updatedPassword,
+		fullName: "Barry B. Benson Jr.",
+	});
+
+	expect(updated).toBeDefined();
+	expect(updated?.fullName).toBe("Barry B. Benson Jr.");
+	expect(updated?.password).not.toBe(updatedPassword);
+
+	const passwordMatches = await bcrypt.compare(
+		updatedPassword,
+		updated?.password ?? ""
+	);
+
+	expect(passwordMatches).toBe(true);
 });
 
 test("Removing a user by ID", async () => {
@@ -134,7 +171,7 @@ test("Removing a user by ID", async () => {
 	expect(deleted?._id.toString()).toBe(user._id.toString());
 });
 
-test("Updating a user by username", async () => {
+test("Updating a user by username without password does not hash password", async () => {
 	const user = new User(dummyUser);
 	const updatedDoc = new User({
 		...dummyUser,
@@ -144,12 +181,40 @@ test("Updating a user by username", async () => {
 	mockingoose(User).toReturn(updatedDoc, "findOneAndUpdate");
 
 	const updated = await updateUserByUsername(user.username, {
-		...dummyUser,
 		fullName: "Barry B. Benson Sr.",
 	});
 
 	expect(updated).toBeDefined();
 	expect(updated?.fullName).toBe("Barry B. Benson Sr.");
+});
+
+test("Updating a user by username hashes password when password is updated", async () => {
+	const user = new User(dummyUser);
+	const updatedPassword = "newhoneypassword";
+	const hashedUpdatedPassword = await bcrypt.hash(updatedPassword, 12);
+	const updatedDoc = new User({
+		...dummyUser,
+		password: hashedUpdatedPassword,
+		fullName: "Barry B. Benson Sr.",
+	});
+	updatedDoc._id = user._id;
+	mockingoose(User).toReturn(updatedDoc, "findOneAndUpdate");
+
+	const updated = await updateUserByUsername(user.username, {
+		...dummyUser,
+		password: updatedPassword,
+		fullName: "Barry B. Benson Sr.",
+	});
+
+	expect(updated).toBeDefined();
+	expect(updated?.fullName).toBe("Barry B. Benson Sr.");
+	expect(updated?.password).not.toBe(updatedPassword);
+
+	const passwordMatches = await bcrypt.compare(
+		updatedPassword,
+		updated?.password ?? ""
+	);
+	expect(passwordMatches).toBe(true);
 });
 
 test("Removing a user by username", async () => {

--- a/packages/express_backend/models/User-Services.test.ts
+++ b/packages/express_backend/models/User-Services.test.ts
@@ -1,4 +1,6 @@
 import mongoose from "mongoose";
+import bcrypt from "bcrypt";
+
 import {
 	expect,
 	test,
@@ -68,7 +70,13 @@ afterEach(async () => {
 test("createUser: success", async () => {
 	expect(u._id).toBeDefined();
 	expect(u.username).toBe(dummyUser.username);
-	expect(u.password).toBe(dummyUser.password);
+	expect(u.password).not.toBe(dummyUser.password);
+
+	const passwordMatches = await bcrypt.compare(
+		dummyUser.password,
+		u.password
+	);
+	expect(passwordMatches).toBe(true);
 	expect(u.fullName).toBe(dummyUser.fullName);
 	expect(u.phone).toBe(dummyUser.phone);
 	expect(u.pronouns).toBe(dummyUser.pronouns);
@@ -243,7 +251,13 @@ test("Updating a user", async () => {
 	const updatedUser = await updateUserById(u._id, updatedData);
 	if (!updatedUser) return;
 	expect(updatedUser).toBeDefined();
-	expect(updatedUser.password).toBe(updatedData.password);
+	expect(updatedUser.password).not.toBe(updatedData.password);
+
+	const passwordMatches = await bcrypt.compare(
+		updatedData.password,
+		updatedUser.password
+	);
+	expect(passwordMatches).toBe(true);
 	expect(updatedUser.pronouns).toBe(dummyUser.pronouns);
 	expect(updatedUser.phone).toBe(dummyUser.phone);
 });
@@ -257,7 +271,13 @@ test("Updating a user by username", async () => {
 	if (!updatedUser) return;
 	expect(updatedUser).toBeDefined();
 	expect(updatedUser._id).toBeDefined();
-	expect(updatedUser.password).toBe(updatedData.password);
+	expect(updatedUser.password).not.toBe(updatedData.password);
+
+	const passwordMatches = await bcrypt.compare(
+		updatedData.password,
+		updatedUser.password
+	);
+	expect(passwordMatches).toBe(true);
 	expect(updatedUser.pronouns).toBe(dummyUser.pronouns);
 	expect(updatedUser.phone).toBe(dummyUser.phone);
 });
@@ -277,4 +297,27 @@ test("Creating a user with an existing username should fail", async () => {
 		expect(err.code).toBe(11000);
 		expect(err.keyValue).toHaveProperty("username");
 	}
+});
+
+test("createUser: same plain password creates different hashes", async () => {
+	const user2 = await createUser({
+		...dummyUser,
+		username: "barrybbenson2",
+	});
+
+	expect(user2.password).not.toBe(dummyUser.password);
+	expect(user2.password).not.toBe(u.password);
+
+	const firstPasswordMatches = await bcrypt.compare(
+		dummyUser.password,
+		u.password
+	);
+
+	const secondPasswordMatches = await bcrypt.compare(
+		dummyUser.password,
+		user2.password
+	);
+
+	expect(firstPasswordMatches).toBe(true);
+	expect(secondPasswordMatches).toBe(true);
 });

--- a/packages/express_backend/models/User-Services.ts
+++ b/packages/express_backend/models/User-Services.ts
@@ -1,10 +1,19 @@
 // user-services.ts
 import { User } from "./User.js";
 import mongoose from "mongoose";
+import bcrypt from "bcrypt";
+
+const SALT_ROUNDS = 12;
 
 // CREATE
-export function createUser(data: any) {
-	return User.create(data);
+export async function createUser(userData: any) {
+	const hashPassword = await bcrypt.hash(userData.password, SALT_ROUNDS);
+
+	//hash new updated password
+	return User.create({
+		...userData,
+		password: hashPassword,
+	});
 }
 
 // READ
@@ -21,12 +30,21 @@ export function getUsersByHomeId(homeId: mongoose.Types.ObjectId) {
 }
 // UPDATE
 // commented out because redundant as we want all methods to use username
-export function updateUserById(
+export async function updateUserById(
 	userId: mongoose.Types.ObjectId | string,
 	data: any
 ) {
-	// { new: true } returns the updated doc
-	return User.findByIdAndUpdate(userId, data, {
+	const updateData = { ...data };
+
+	//hash new updated password
+	if (updateData.password) {
+		updateData.password = await bcrypt.hash(
+			updateData.password,
+			SALT_ROUNDS
+		);
+	}
+
+	return User.findByIdAndUpdate(userId, updateData, {
 		returnDocument: "after",
 		runValidators: true,
 	});
@@ -42,9 +60,18 @@ export function getUsersByHomeAndRelation(
 }
 
 // UPDATE
-export function updateUserByUsername(username: string, data: any) {
-	// { new: true } returns the updated doc
-	return User.findOneAndUpdate({ username }, data, {
+export async function updateUserByUsername(username: string, data: any) {
+	const updateData = { ...data };
+
+	//hash new updated password
+	if (updateData.password) {
+		updateData.password = await bcrypt.hash(
+			updateData.password,
+			SALT_ROUNDS
+		);
+	}
+
+	return User.findOneAndUpdate({ username }, updateData, {
 		returnDocument: "after",
 		runValidators: true,
 	});

--- a/packages/express_backend/routes/login-routes.ts
+++ b/packages/express_backend/routes/login-routes.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import type { Request, Response } from "express";
 import { User } from "../models/User.js";
+import bcrypt from "bcrypt";
 
 export const loginRouter = express.Router();
 
@@ -22,7 +23,8 @@ loginRouter.post("/login", async (req: Request, res: Response) => {
 				.json({ error: "Invalid Username or Password" });
 		}
 
-		if (user.password !== password) {
+		const passwordHashMatches = bcrypt.compare(password, user.password);
+		if (!passwordHashMatches) {
 			return res
 				.status(401)
 				.json({ error: "Invalid Username or Password" });

--- a/packages/express_backend/swagger-output.json
+++ b/packages/express_backend/swagger-output.json
@@ -1,1335 +1,1331 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "title": "Room8 API",
-    "description": "API documentation",
-    "version": "1.0.0"
-  },
-  "host": "localhost:8000",
-  "basePath": "/",
-  "schemes": [
-    "http"
-  ],
-  "paths": {
-    "/": {
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/{homeCode}/chores": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      },
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/{homeCode}/chores/{choreId}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "choreId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      },
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "choreId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "choreId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/homes": {
-      "post": {
-        "description": "",
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/homes/{id}": {
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/homes/id/{id}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/homes/code/{code}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/events/ics/{id}": {
-      "get": {
-        "description": "",
-        "produces": [
-          "text/calendar; charset=utf-8"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/homeId/{home}/events": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/{home}/events/{id}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/{homeCode}/events": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/events/{eventId}": {
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "eventId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "eventId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/login": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "username": {
-                  "example": "any"
-                },
-                "password": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/logout": {
-      "post": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/homeId/{homeId}/rules": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/homes/rules/{homeCode}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/{homeCode}/rules": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/homes/rules": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "example": "any"
-                },
-                "status": {
-                  "example": "any"
-                },
-                "homeCode": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/rules/{ruleId}": {
-      "put": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "ruleId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "ruleId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/rules/{ruleId}/vote": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "ruleId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "voteId": {
-                  "example": "any"
-                },
-                "vote": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/rules/{ruleId}/delete-vote": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "ruleId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "voteId": {
-                  "example": "any"
-                },
-                "vote": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/users": {
-      "post": {
-        "description": "",
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          }
-        }
-      }
-    },
-    "/users/me": {
-      "patch": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/users/{username}": {
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/users/{id}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/users/username/{username}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/users/home/{homeId}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/{home}/grocery": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/{home}/grocery/{id}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "delete": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      },
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/{home}/grocery/{id}/{newQuantity}": {
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "home",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "newQuantity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/relate/me/{homeCode}": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "relationship": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/relate/me": {
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/relate/me/{homeName}": {
-      "patch": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeName",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/relate/{homeCode}/{relation}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "relation",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/relate/home/{homeId}/residents": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/auth/residents/{homeCode}/": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    },
-    "/auth/homeDisplay/me/{homeCode}/": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "homeCode",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        }
-      }
-    }
-  }
+	"swagger": "2.0",
+	"info": {
+		"title": "Room8 API",
+		"description": "API documentation",
+		"version": "1.0.0"
+	},
+	"host": "localhost:8000",
+	"basePath": "/",
+	"schemes": ["http"],
+	"paths": {
+		"/": {
+			"get": {
+				"description": "",
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				}
+			}
+		},
+		"/{homeCode}/chores": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			},
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/{homeCode}/chores/{choreId}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "choreId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			},
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "choreId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "choreId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/homes": {
+			"post": {
+				"description": "",
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/homes/{id}": {
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/homes/id/{id}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/homes/code/{code}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "code",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/events/ics/{id}": {
+			"get": {
+				"description": "",
+				"produces": ["text/calendar; charset=utf-8"],
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/homeId/{home}/events": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/{home}/events/{id}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/{homeCode}/events": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/events/{eventId}": {
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "eventId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "eventId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/login": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"username": {
+									"example": "any"
+								},
+								"password": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/logout": {
+			"post": {
+				"description": "",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/homeId/{homeId}/rules": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/homes/rules/{homeCode}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/{homeCode}/rules": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"description": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/homes/rules": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"description": {
+									"example": "any"
+								},
+								"status": {
+									"example": "any"
+								},
+								"homeCode": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/rules/{ruleId}": {
+			"put": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "ruleId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "ruleId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/rules/{ruleId}/vote": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "ruleId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"voteId": {
+									"example": "any"
+								},
+								"vote": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/rules/{ruleId}/delete-vote": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "ruleId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"voteId": {
+									"example": "any"
+								},
+								"vote": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/users": {
+			"post": {
+				"description": "",
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
+		"/users/me": {
+			"patch": {
+				"description": "",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"get": {
+				"description": "",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/users/{username}": {
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/users/{id}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/users/username/{username}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/users/home/{homeId}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/{home}/grocery": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/{home}/grocery/{id}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/{home}/grocery/{id}/{newQuantity}": {
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "home",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "newQuantity",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/relate/me/{homeCode}": {
+			"post": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"relationship": {
+									"example": "any"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/relate/me": {
+			"get": {
+				"description": "",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/relate/me/{homeName}": {
+			"patch": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeName",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/relate/{homeCode}/{relation}": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "relation",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/relate/home/{homeId}/residents": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
+		"/auth/residents/{homeCode}/": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/auth/homeDisplay/me/{homeCode}/": {
+			"get": {
+				"description": "",
+				"parameters": [
+					{
+						"name": "homeCode",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Add bcrypt hashing when users are created or update their password. Update login to compare passwords with bcrypt.compare and adjust User-Services tests for hashed password behavior.

# Summary of implementation

_Briefly describe what this PR does and why it exists._

This Pr implements hashing passwords, when they are creating a new acc. & updating. This fixes comparing users passwords when trying to log in. As well as backend User-severs testing to implement and test the hashing, achieving 100% testing for the backend files I have change. 


# Problem and Solution

_What issue, bug, or limitation is being addressed? OR What is being solved_
requirement for our final project.

# File Changes

_List significant files and what changed in each._

```txt

packages/express_backend/models/User-Services.ts
packages/express_backend/models/User-Services.test.ts
packages/express_backend/models/User-Services-Mock.test.ts
packages/express_backend/routes/login-routes.ts

```

# Breaking Changes

_Describe any breaking changes. If none, state "None"._

None

# How was this tested?

_How was this tested?_

- npm run test:backend
- npm run coverage:backend

<img width="808" height="327" alt="Screenshot 2026-05-24 at 7 18 49 PM" src="https://github.com/user-attachments/assets/b05299fc-a8c1-4058-9a02-f83664178d4f" />

# Setup and Checklist for reviewers

- [x] run "npm i" 

- [x] run 
```
npm run test:backend
``` 

note: you will notice it take some time now to run the test!!!

- [x] In the account you are using when logging in. you can update the password and check on Compass to see if the password is hash

- [x] if you dont want to do the above check, then make a new account and check compass if the password is hash


# Issues linked

closes #148 
