### PR TITLE
fix: add bcrypt to backend workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15463,6 +15463,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"bcrypt": "^6.0.0",
 				"connect-mongo": "^6.0.0",
 				"cors": "^2.8.6",
 				"dotenv": "^17.3.1",
@@ -15477,6 +15478,7 @@
 				"swagger-ui-express": "^5.0.1"
 			},
 			"devDependencies": {
+				"@types/bcrypt": "^6.0.0",
 				"@types/cors": "^2.8.19",
 				"@types/express": "^5.0.6",
 				"@types/express-session": "^1.19.0",

--- a/packages/express_backend/package.json
+++ b/packages/express_backend/package.json
@@ -22,6 +22,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
+		"bcrypt": "^6.0.0",
 		"connect-mongo": "^6.0.0",
 		"cors": "^2.8.6",
 		"dotenv": "^17.3.1",
@@ -36,6 +37,7 @@
 		"swagger-ui-express": "^5.0.1"
 	},
 	"devDependencies": {
+		"@types/bcrypt": "^6.0.0",
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.6",
 		"@types/express-session": "^1.19.0",


### PR DESCRIPTION
## Summary
Adds bcrypt dependencies to the backend workspace so the backend build can resolve bcrypt imports.

## Changes
- Add bcrypt to packages/express_backend
- Add @types/bcrypt for TypeScript build support
- Update lockfile

## Testing
- Fixes backend build error: Cannot find module 'bcrypt'