### PR TITLE
Guest ascension minus the voting

### DIFF
--- a/packages/express_backend/routes/authentication-router.ts
+++ b/packages/express_backend/routes/authentication-router.ts
@@ -53,6 +53,40 @@ function filterResidents(residents: any[], userOneRelation: string) {
 	});
 }
 
+function filterGuests(guests: any[], userOneRelation: string) {
+	return guests.map((guests) => {
+		return {
+			_id: guests._id,
+			fullName: guests.fullName,
+			allergens: guests.allergens,
+			pronouns: canSeeGuest(
+				guests.visibility.pronounsVisible,
+				userOneRelation
+			)
+				? guests.pronouns
+				: undefined,
+			DOB: canSeeGuest(guests.visibility.dobVisible, userOneRelation)
+				? guests.DOB
+				: undefined,
+			likes: canSeeGuest(guests.visibility.likesVisible, userOneRelation)
+				? guests.likes
+				: undefined,
+			dislikes: canSeeGuest(
+				guests.visibility.dislikesVisible,
+				userOneRelation
+			)
+				? guests.dislikes
+				: undefined,
+			emergencyContact: canSeeGuest(
+				guests.visibility.emergencyContactVisible,
+				userOneRelation
+			)
+				? guests.emergencyContact
+				: undefined,
+		};
+	});
+}
+
 function canSee(fieldVisible: string, userOneRelation: string): boolean {
 	if (!fieldVisible) {
 		return false;
@@ -61,6 +95,15 @@ function canSee(fieldVisible: string, userOneRelation: string): boolean {
 		return true;
 	}
 	if (fieldVisible === "RESIDENT" && userOneRelation === "RESIDENT") {
+		return true;
+	}
+	return false;
+}
+function canSeeGuest(fieldVisible: string, userOneRelation: string): boolean {
+	if (!fieldVisible) {
+		return false;
+	}
+	if (fieldVisible === "PUBLIC") {
 		return true;
 	}
 	return false;
@@ -146,7 +189,7 @@ authRouter.get(
 				.status(404)
 				.json({ error: "No shared home found between users" });
 		}
-		const filteredUsers = filterResidents(guests, userOneRelation);
+		const filteredUsers = filterGuests(guests, userOneRelation);
 
 		res.status(200).json(filteredUsers);
 	}

--- a/packages/express_backend/routes/authentication-router.ts
+++ b/packages/express_backend/routes/authentication-router.ts
@@ -71,7 +71,7 @@ authRouter.get(
 	requireAuth,
 	async (req: Request, res: Response) => {
 		const { homeCode } = req.params;
-		console.log("Received request for residents with params:", req.params);
+
 		// uses session cookies
 		const userOne = await getUserById(
 			new mongoose.Types.ObjectId(req.session.userId)
@@ -109,13 +109,51 @@ authRouter.get(
 );
 
 authRouter.get(
+	"/auth/guests/me/:homeCode/",
+	requireAuth,
+	async (req: Request, res: Response) => {
+		const { homeCode } = req.params;
+
+		// uses session cookies
+		const userOne = await getUserById(
+			new mongoose.Types.ObjectId(req.session.userId)
+		);
+		const home = await getHomeByCode(homeCode.toString());
+		if (!userOne || !home) {
+			console.log("User or home not found");
+			return res.status(404).json({ error: "User or home not found" });
+		}
+
+		const guests = await getUsersByHomeAndRelation(home._id, "GUEST");
+
+		if (guests.length === 0) {
+			console.log("No guests found for home code: " + homeCode);
+			return res.status(404).json({
+				error: "No residents found for the provided home code",
+			});
+		}
+
+		const userOneRelationObject = await getUserHomeRelation(
+			userOne._id,
+			home._id
+		);
+		const userOneRelation = userOneRelationObject?.homeIds[0].relationship;
+		if (!userOneRelation) {
+			console.log("No shared home found between user and home");
+			return res
+				.status(404)
+				.json({ error: "No shared home found between users" });
+		}
+		const filteredUsers = filterResidents(guests, userOneRelation);
+
+		res.status(200).json(filteredUsers);
+	}
+);
+
+authRouter.get(
 	"/auth/homeDisplay/me/:homeCode/",
 	requireAuth,
 	async (req: Request, res: Response) => {
-		console.log(
-			"Received request for home display with params:",
-			req.params
-		);
 		const { homeCode } = req.params;
 		const home = await getHomeByCode(homeCode.toString());
 		if (!home) {
@@ -145,7 +183,6 @@ authRouter.get(
 				events: await getUpcomingEventsByHome(home._id),
 			};
 			res.status(200).json(homeDisplay);
-			console.log("Home Display for resident:", homeDisplay);
 		} else {
 			const homeDisplay = {
 				name: home.homeName,
@@ -153,7 +190,7 @@ authRouter.get(
 				rules: await getApprovedRulesByHome(home._id),
 				events: await getUpcomingEventsByHome(home._id),
 			};
-			console.log("Home Display for non-resident:", homeDisplay);
+
 			res.status(200).json(homeDisplay);
 		}
 	}

--- a/packages/express_backend/routes/authentication-router.ts
+++ b/packages/express_backend/routes/authentication-router.ts
@@ -25,6 +25,9 @@ function filterResidents(residents: any[], userOneRelation: string) {
 			_id: resident._id,
 			fullName: resident.fullName,
 			allergens: resident.allergens,
+			phone: canSee(resident.visibility.phoneVisible, userOneRelation)
+				? resident.phone
+				: undefined,
 			pronouns: canSee(
 				resident.visibility.pronounsVisible,
 				userOneRelation
@@ -59,6 +62,9 @@ function filterGuests(guests: any[], userOneRelation: string) {
 			_id: guests._id,
 			fullName: guests.fullName,
 			allergens: guests.allergens,
+			phone: canSeeGuest(guests.visibility.phoneVisible, userOneRelation)
+				? guests.phone
+				: undefined,
 			pronouns: canSeeGuest(
 				guests.visibility.pronounsVisible,
 				userOneRelation

--- a/packages/express_backend/routes/authentication-router.ts
+++ b/packages/express_backend/routes/authentication-router.ts
@@ -66,6 +66,7 @@ function canSee(fieldVisible: string, userOneRelation: string): boolean {
 	return false;
 }
 
+//gets residents of a home and their information based on the relationship of the user making the request to the home
 authRouter.get(
 	"/auth/residents/:homeCode/",
 	requireAuth,
@@ -108,6 +109,7 @@ authRouter.get(
 	}
 );
 
+//gets guests of a home and their information based on the relationship of the user making the request to the home
 authRouter.get(
 	"/auth/guests/me/:homeCode/",
 	requireAuth,
@@ -193,5 +195,32 @@ authRouter.get(
 
 			res.status(200).json(homeDisplay);
 		}
+	}
+);
+
+//gets a users relationship to a home based on the home code
+authRouter.get(
+	"/auth/relationship/me/:homeCode/",
+	requireAuth,
+	async (req: Request, res: Response) => {
+		const { homeCode } = req.params;
+		const home = await getHomeByCode(homeCode.toString());
+		if (!home) {
+			return res.status(404).json({ error: "User or home not found" });
+		}
+
+		const userRelationObject = await getUserHomeRelation(
+			new mongoose.Types.ObjectId(req.session.userId),
+			home._id
+		);
+		const userRelation = userRelationObject?.homeIds[0].relationship;
+		if (!userRelation) {
+			console.log("No shared home found between user and home");
+			return res
+				.status(404)
+				.json({ error: "No shared home found between users" });
+		}
+
+		res.status(200).json({ relationship: userRelation });
 	}
 );

--- a/packages/express_backend/routes/relation-routes.ts
+++ b/packages/express_backend/routes/relation-routes.ts
@@ -181,6 +181,74 @@ relationRouter.patch(
 	}
 );
 
+//patch route to update a users relationship to a home, used for changing resident to guest or vice versa
+relationRouter.patch(
+	"/relate/me/:homeName/:newRelation",
+	requireAuth,
+	async (req: Request, res: Response) => {
+		try {
+			console.log("Updating relation!");
+
+			const homename = req.params.homeName;
+			const newRelation = req.params.newRelation;
+
+			if (typeof homename !== "string") {
+				return res.status(400).json({ error: "Invalid home name" });
+			}
+
+			const h = await getHomeByName(homename);
+
+			if (!h) {
+				return res.status(404).json({ error: "Home not found" });
+			}
+
+			const userId = getSessionUserId(req);
+			if (!userId) {
+				return res
+					.status(400)
+					.json({ error: "Invalid user id in session" });
+			}
+
+			const u = await getUserById(userId);
+
+			if (!u) {
+				return res.status(404).json({ error: "User not found" });
+			}
+			const updatedHome = await updateHome(h._id, {
+				userIds: h.userIds.map((user) =>
+					user.userId.equals(u._id)
+						? { userId: user.userId, relationship: newRelation }
+						: user
+				),
+			});
+			if (!updatedHome) {
+				return res
+					.status(404)
+					.json({ error: "Home not found for update" });
+			}
+			await h.save();
+			const updatedUser = await updateUserById(u._id, {
+				homeIds: u.homeIds.map((home) =>
+					home.homeId.equals(h._id)
+						? { homeId: home.homeId, relationship: newRelation }
+						: home
+				),
+			});
+			if (!updatedUser) {
+				return res
+					.status(404)
+					.json({ error: "User not found for update" });
+			}
+			await u.save();
+
+			res.status(200).json(h);
+		} catch (err) {
+			console.error(err);
+			res.status(500).json({ error: "Failed to update relationship" });
+		}
+	}
+);
+
 //get users based off passed in home and relation
 relationRouter.get(
 	"/relate/:homeCode/:relation",

--- a/packages/react-frontend/src/components/GuestVoteOverlay.tsx
+++ b/packages/react-frontend/src/components/GuestVoteOverlay.tsx
@@ -1,0 +1,71 @@
+import React, { type ReactNode, useState } from "react";
+import { API_BASE } from "../config";
+import List from "./list";
+
+type Guest = {
+	_id: string;
+	fullName: string;
+};
+
+type GuestVoteOverlayProps<Guest> = {
+	guests: Guest[];
+	homeCode: string;
+	username: string;
+};
+
+export default function GuestVoteOverlay({
+	guests,
+	homeCode,
+}: GuestVoteOverlayProps<Guest>) {
+	const [vote, setVote] = useState<"approve" | "reject" | "abstain" | null>(
+		null
+	);
+	const [errorMsg, setErrorMsg] = useState("");
+
+	/*async function submitVote() {
+        if (!vote) {
+            setErrorMsg("Please select a vote option.");
+            return;
+        }
+
+        try {
+            const response = await fetch(`${API_BASE}/rules/vote/${ruleId}`, {
+                method: "POST",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ vote }),
+            });
+
+            if (!response.ok) {
+                const data = await response.json();
+                throw new Error(data.error || "Failed to submit vote.");
+            }
+
+            setErrorMsg("");
+        } catch (error) {
+            setErrorMsg(error.message);
+        }
+    }*/
+
+	return (
+		<div className="overlay">
+			<h2>Vote on Guest Ascencion</h2>
+			<div>
+				<List
+					item=""
+					items={guests}
+					handleAddClick={() => {}}
+					handleRemoveClick={() => {}}
+					getKey={(guests: Guest) => guests._id}
+					renderItem={(guest: Guest) => (
+						<div>
+							<p>{guest.fullName}</p>
+							<button className="button">Yes</button>
+						</div>
+					)}
+					homeCode={homeCode ? [homeCode] : undefined}
+				></List>
+			</div>
+		</div>
+	);
+}

--- a/packages/react-frontend/src/components/addHomeOverlay.tsx
+++ b/packages/react-frontend/src/components/addHomeOverlay.tsx
@@ -12,7 +12,7 @@ export default function AddHomeOverlay({ onBack, onAdd }: AddHomeProps) {
 	const [homeCode, setHomeCode] = useState("");
 	const [errorMsg, setErrorMsg] = useState("");
 	async function addHome() {
-		const relationship = { relationship: "RESIDENT" };
+		const relationship = { relationship: "GUEST" };
 		const promise = await fetch(`${API_BASE}/relate/me/${homeCode}`, {
 			method: "POST",
 			credentials: "include",

--- a/packages/react-frontend/src/pages/residents.tsx
+++ b/packages/react-frontend/src/pages/residents.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect } from "react";
 import List from "../components/list";
 import { useParams, useNavigate } from "react-router-dom";
 import { API_BASE } from "../config";
+import GuestVoteOverlay from "../components/GuestVoteOverlay";
+import Overlay from "../components/overlay";
 
 export default function Residents() {
 	const [residents, setResidents] = useState<any[]>([]);
 	const [guests, setGuests] = useState<any[]>([]);
 	const [relationship, setRelationship] = useState<string>("");
 	const { homeCode } = useParams();
+	const [openVotePanel, setOpenVotePanel] = useState(false);
 	const navigate = useNavigate();
 	async function fetchResidents() {
 		if (!homeCode) return;
@@ -78,6 +81,18 @@ export default function Residents() {
 					←
 				</button>
 			</div>
+			{openVotePanel && (
+				<Overlay
+					isOpen={openVotePanel}
+					onClose={() => setOpenVotePanel(false)}
+				>
+					<GuestVoteOverlay
+						guests={guests}
+						homeCode={homeCode || ""}
+						username={""}
+					/>
+				</Overlay>
+			)}
 			<div className="flex flex-col items-center">
 				<h1 className="header ">Residents</h1>
 				<List
@@ -90,11 +105,11 @@ export default function Residents() {
 							<h1 className="header-secondary">
 								{resident.fullName}
 							</h1>
-							{resident.allergies &&
-							resident.allergies.length > 0 ? (
+							{resident.allergens &&
+							resident.allergens.length > 0 ? (
 								<p>
-									Allergies:{" "}
-									{resident.allergies.join(", ") || "None"}
+									Allergies:
+									{resident.allergens?.join(", ") || "None"}
 								</p>
 							) : (
 								<p />
@@ -248,14 +263,21 @@ export default function Residents() {
 								) : (
 									<p />
 								)}
-								{relationship === "RESIDENT" && (
-									<button>Vote to Become Resident</button>
-								)}
 							</div>
 						)}
 						getKey={(guest) => guest._id}
 						homeCode={homeCode ? [homeCode] : undefined}
 					/>
+					{relationship === "RESIDENT" && (
+						<button
+							className="button"
+							onClick={() => {
+								setOpenVotePanel(true);
+							}}
+						>
+							Vote
+						</button>
+					)}
 				</div>
 			) : (
 				<p className="text-center mt-4">

--- a/packages/react-frontend/src/pages/residents.tsx
+++ b/packages/react-frontend/src/pages/residents.tsx
@@ -5,6 +5,7 @@ import { API_BASE } from "../config";
 
 export default function Residents() {
 	const [residents, setResidents] = useState<any[]>([]);
+	const [guests, setGuests] = useState<any[]>([]);
 	const { homeCode } = useParams();
 	const navigate = useNavigate();
 	async function fetchResidents() {
@@ -23,8 +24,26 @@ export default function Residents() {
 				setResidents([]);
 			});
 	}
+	async function fetchGuests() {
+		if (!homeCode) return;
+
+		fetch(`${API_BASE}/auth/guests/me/${homeCode}`, {
+			credentials: "include",
+		})
+			.then((res) => {
+				if (!res.ok)
+					console.log("Guests not found for home code: " + homeCode);
+				return res.json();
+			})
+			.then((data) => setGuests(data))
+			.catch((err) => {
+				console.error(err);
+				setGuests([]);
+			});
+	}
 	useEffect(() => {
 		fetchResidents().catch(console.error);
+		fetchGuests().catch(console.error);
 	}, [homeCode]);
 	return (
 		<div className="flex flex-col">
@@ -49,10 +68,16 @@ export default function Residents() {
 							<h1 className="header-secondary">
 								{resident.fullName}
 							</h1>
-							<p>
-								Allergens:{" "}
-								{resident.allergens.join(", ") || "None"}
-							</p>
+							{resident.allergies &&
+							resident.allergies.length > 0 ? (
+								<p>
+									Allergies:{" "}
+									{resident.allergies.join(", ") || "None"}
+								</p>
+							) : (
+								<p />
+							)}
+
 							{resident.pronouns ? (
 								<div>
 									<p>
@@ -118,6 +143,100 @@ export default function Residents() {
 					homeCode={homeCode ? [homeCode] : undefined}
 				/>
 			</div>
+			{guests.length > 0 ? (
+				<div className="flex flex-col items-center">
+					<h1 className="header ">Guests</h1>
+					<List
+						item="Guests"
+						items={guests}
+						handleAddClick={() => {}}
+						handleRemoveClick={() => {}}
+						renderItem={(guest) => (
+							<div className="flex flex-row gap-4">
+								<h1 className="header-secondary">
+									{guest.fullName}
+								</h1>
+								{guest.allergies &&
+								guest.allergies.length > 0 ? (
+									<p>
+										Allergies:{" "}
+										{guest.allergies.join(", ") || "None"}
+									</p>
+								) : (
+									<p />
+								)}
+
+								{guest.pronouns ? (
+									<div>
+										<p>
+											Dislikes: {guest.pronouns || "N/A"}
+										</p>
+									</div>
+								) : (
+									<p />
+								)}
+								{guest.DOB ? (
+									<div>
+										<p>
+											Date of Birth: {guest.DOB || "N/A"}
+										</p>
+									</div>
+								) : (
+									<p />
+								)}
+								{guest.likes ? (
+									<div>
+										<p>
+											Likes:{" "}
+											{guest.likes?.join(", ") || "N/A"}
+										</p>
+									</div>
+								) : (
+									<p />
+								)}
+								{guest.dislikes ? (
+									<div>
+										<p>
+											Dislikes:{" "}
+											{guest.dislikes?.join(", ") ||
+												"N/A"}
+										</p>
+									</div>
+								) : (
+									<p />
+								)}
+								{guest.emergencyContact ? (
+									<div>
+										<p>
+											Emergency Contact Name:{" "}
+											{guest.emergencyContact.name ||
+												"N/A"}
+										</p>
+										<p>
+											Emergency Contact Phone:{" "}
+											{guest.emergencyContact.phone ||
+												"N/A"}
+										</p>
+										<p>
+											Emergency Contact Relationship:{" "}
+											{guest.emergencyContact
+												.relationship || "N/A"}
+										</p>
+									</div>
+								) : (
+									<p />
+								)}
+							</div>
+						)}
+						getKey={(guest) => guest._id}
+						homeCode={homeCode ? [homeCode] : undefined}
+					/>
+				</div>
+			) : (
+				<p className="text-center mt-4">
+					No guests found for this home.
+				</p>
+			)}
 		</div>
 	);
 }

--- a/packages/react-frontend/src/pages/residents.tsx
+++ b/packages/react-frontend/src/pages/residents.tsx
@@ -6,6 +6,7 @@ import { API_BASE } from "../config";
 export default function Residents() {
 	const [residents, setResidents] = useState<any[]>([]);
 	const [guests, setGuests] = useState<any[]>([]);
+	const [relationship, setRelationship] = useState<string>("");
 	const { homeCode } = useParams();
 	const navigate = useNavigate();
 	async function fetchResidents() {
@@ -41,9 +42,30 @@ export default function Residents() {
 				setGuests([]);
 			});
 	}
+	async function fetchRelationship() {
+		if (!homeCode) return;
+
+		fetch(`${API_BASE}/auth/relationship/me/${homeCode}`, {
+			credentials: "include",
+		})
+			.then((res) => {
+				if (!res.ok)
+					console.log(
+						"Relationship not found for home code: " + homeCode
+					);
+				return res.json();
+			})
+			.then((data) => setRelationship(data.relationship))
+			.catch((err) => {
+				console.error(err);
+				setRelationship("");
+			});
+		console.log("Relationship: " + relationship);
+	}
 	useEffect(() => {
 		fetchResidents().catch(console.error);
 		fetchGuests().catch(console.error);
+		fetchRelationship().catch(console.error);
 	}, [homeCode]);
 	return (
 		<div className="flex flex-col">
@@ -225,6 +247,9 @@ export default function Residents() {
 									</div>
 								) : (
 									<p />
+								)}
+								{relationship === "RESIDENT" && (
+									<button>Vote to Become Resident</button>
 								)}
 							</div>
 						)}


### PR DESCRIPTION
# Summary of implementation

Extended the residents page such that guests and their allergens and publicly accessible data can be seen on the residents page of the home. Additionally, implemented the feature such that if a user on the residents page has a residents relationship, they can click a voting button which will allow them to see an overlay of the guests and some voting buttons (NOTE: this voting functionality is another issue which will be completed next sprint). Additionally, incorporated a route that changes a users' relation to a home to be used once the voting functionality is completed.

# Problem and Solution

Currently, users connecting to a home with a home code are connected as residents, but to improve security/authentication, we want users who connect to a home with a home code to be connected as guests, and then get voted by residents to ascend to a guest. Solution was to implement front-end feature for residents to see guests within a home and to give them the functionality to vote (just frontend for now). 

# File Changes
relations-route.ts
authentication-route.ts
residents.tsx
GuestOverlay.tsx

# Breaking Changes

Users connecting to a home are now automatically related as guests

# How was this tested?

- npm run coverage
-  Log in and go to a home's residents page they are a guest of (may need to postman change them to a guest or connect to a new home). Verify that they can not vote. Go to a home's residents page that they are a resident of, verify that they can click and see an overview
- Test either using swagger or postman that you can change a resident to a guest, and then a guest to a resident. 
If using postman, sign in first using http://localhost:8000/login w/ the body as 
{
  "username": "insert user name",
  "password": "insert pass word"
}
Then try out the routes
http://localhost:8000/relate/me/HOME OF CHOICE/GUEST
http://localhost:8000/relate/me/HOME OF CHOICE/RESIDENT

# Setup and Checklist for reviewers

- [ ] npm run coverage
- [ ] Verify that guests are visible on residents page
- [ ] Verify that residents can "vote" on guests and that guests cannot vote
- [ ] Verify that you can alter a users connection to a home with the new relate/me/homeCode/relationship route

# Issues linked

closes #191 
# Notes
The voting feature and CSS are future issues, so the guest ascension MVP is not yet complete.