### PR TITLE
Add Cypress testing to CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,33 @@
+name: Cypress E2E
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+jobs:
+    cypress:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - run: npm ci
+
+            - name: Build frontend
+              run: npm -w packages/react-frontend run build
+
+            - name: Run Cypress tests
+              uses: cypress-io/github-action@v6
+              with:
+                  install-command: npm install cypress --no-save
+                  start: npm -w packages/react-frontend run dev -- --host 0.0.0.0
+                  wait-on: http://127.0.0.1:5173
+                  config-file: packages/react-frontend/cypress.config.cjs
+                  browser: chrome

--- a/packages/react-frontend/cypress.config.cjs
+++ b/packages/react-frontend/cypress.config.cjs
@@ -1,0 +1,9 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+    e2e: {
+        baseUrl: 'http://127.0.0.1:5173',
+        supportFile: false,
+        specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}'
+    }
+});

--- a/packages/react-frontend/cypress/e2e/app.cy.js
+++ b/packages/react-frontend/cypress/e2e/app.cy.js
@@ -1,0 +1,6 @@
+describe('Room8 app', () => {
+    it('loads the sign in page', () => {
+        cy.visit('/');
+        cy.contains(/sign|login/i);
+    });
+});


### PR DESCRIPTION
## Summary
- add dedicated Cypress GitHub Actions workflow
- install Cypress in CI without modifying package-lock
- add Cypress config for the React frontend
- add starter e2e smoke test for the sign-in page

## Notes
This keeps the existing CI workflow unchanged and adds a separate e2e pipeline for browser testing.
